### PR TITLE
Feature Add to include basic Cognito Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
+<img src="https://cdn.ellaisys.com/aws-cognito/banner.png" width="100%" alt="EllaiSys AWS Cloud Capability"/>
+
 # Laravel Package to manage Web and API authentication with AWS Cognito
 AWS Cognito package using the AWS SDK for PHP
-Adapted for use with a pure api
 
+![Latest Version on Packagist](https://img.shields.io/packagist/v/ellaisys/aws-cognito?style=flat-square)
+![Release Date](https://img.shields.io/github/release-date/ellaisys/aws-cognito?style=flat-square)
+![Total Downloads](https://img.shields.io/packagist/dt/ellaisys/aws-cognito?style=flat-square)
+![](https://img.shields.io/github/stars/ellaisys/aws-cognito?style=flat-square)
+![](https://img.shields.io/github/forks/ellaisys/aws-cognito?style=flat-square)
+![APM](https://img.shields.io/packagist/l/ellaisys/aws-cognito?style=flat-square)
 
 This package provides a simple way to use AWS Cognito authentication in Laravel 7.x for Web and API Auth Drivers.
 The idea of this package, and some of the code, is based on the package from Pod-Point which you can find here: [Pod-Point/laravel-cognito-auth](https://github.com/Pod-Point/laravel-cognito-auth), [black-bits/laravel-cognito-auth](https://github.com/black-bits/laravel-cognito-auth) and [tymondesigns/jwt-auth](https://github.com/tymondesigns/jwt-auth).
 
 **[DEMO Application](https://demo.ellaisys.com/cognito)**. You can try and register and login. For the first time, it will force the user to change password. The **[source code](https://github.com/ellaisys/demo_cognito_app)** of the demo application is also available of the GitHub.
 
-We decided to use it and contribute it to the community as a package, that encourages standarised use and a RAD tool for authentication using AWS Cognito. 
+We decided to use it and contribute it to the community as a package, that encourages standarised use and a RAD tool for authentication using AWS Cognito.
 
 ## Features
 - Registration and Confirmation E-Mail
@@ -25,6 +32,7 @@ We decided to use it and contribute it to the community as a package, that encou
 - DynamoDB support for Web Sessions and API Tokens (useful for server redundency OR multiple containers)
 - Easy configuration of Token Expiry (Manage using the cognito console, no code or configurations needed)
 - Support for App Client without Secret **(NEW Feature)**
+- Support for Cognito Groups, including assigning a default group to a new user **(NEW Feature)**
 
 ## Compatability
 
@@ -65,7 +73,7 @@ Next you can publish the config and the view.
 ```bash
     php artisan vendor:publish --provider="Ellaisys\Cognito\Providers\AwsCognitoServiceProvider"
 ```
-Last but not least you want to change the auth driver. To do so got to your config\auth.php file and change it 
+Last but not least you want to change the auth driver. To do so got to your config\auth.php file and change it
 to look the following:
 
 ```php
@@ -83,14 +91,14 @@ to look the following:
 
 ## Cognito User Pool
 
-In order to use AWS Cognito as authentication provider, you require a Cognito User Pool. 
+In order to use AWS Cognito as authentication provider, you require a Cognito User Pool.
 
-If you haven't created one already, go to your [Amazon management console](https://console.aws.amazon.com/cognito/home) and create a new user pool. 
+If you haven't created one already, go to your [Amazon management console](https://console.aws.amazon.com/cognito/home) and create a new user pool.
 
 Next, generate an App Client. This will give you the App client id and the App client secret
-you need for your `.env` file. 
+you need for your `.env` file.
 
-*IMPORTANT: Don't forget to activate the checkbox to Enable sign-in API for server-based Authentication. 
+*IMPORTANT: Don't forget to activate the checkbox to Enable sign-in API for server-based Authentication.
 The Auth Flow is called: ADMIN_USER_PASSWORD_AUTH (formerly ADMIN_NO_SRP_AUTH)*
 
 ### AWS IAM configuration
@@ -140,27 +148,27 @@ Our package is providing you 6 traits you can just add to your Auth Controllers 
 
 In the simplest way you just go through your Auth Controllers and change namespaces from the traits which are currently implemented from Laravel.
 
-You can change structure to suit your needs. Please be aware of the @extend statement in the blade file to fit into your project structure. 
-At the current state you need to have those 4 form fields defined in here. Those are `token`, `email`, `password`, `password_confirmation`. 
+You can change structure to suit your needs. Please be aware of the @extend statement in the blade file to fit into your project structure.
+At the current state you need to have those 4 form fields defined in here. Those are `token`, `email`, `password`, `password_confirmation`.
 
 ## Single Sign-On
 
-With our package and AWS Cognito we provide you a simple way to use Single Sign-Ons. 
+With our package and AWS Cognito we provide you a simple way to use Single Sign-Ons.
 For configuration options take a look at the config [cognito.php](/config/cognito.php).
 
 
 When you want SSO enabled and a user tries to login into your application, the package checks if the user exists in your AWS Cognito pool. If the user exists, he will be created automatically in your database provided the `add_missing_local_user_sso` is to `true`, and is logged in simultaneously.
 
-That's what we use the fields `sso_user_model` and `cognito_user_fields` for. In `sso_user_model` you define the class of your user model. In most cases this will simply be _App\User_. 
+That's what we use the fields `sso_user_model` and `cognito_user_fields` for. In `sso_user_model` you define the class of your user model. In most cases this will simply be _App\User_.
 
-With `cognito_user_fields` you can define the fields which should be stored in Cognito. Put attention here. If you define a field which you do not send with the Register Request this will throw you an InvalidUserFieldException and you won't be able to register. 
+With `cognito_user_fields` you can define the fields which should be stored in Cognito. Put attention here. If you define a field which you do not send with the Register Request this will throw you an InvalidUserFieldException and you won't be able to register.
 
-Now that you have registered your users with their attributes in the AWS Cognito pool and your database and you want to attach a second app which should use the same pool. Well, that's actually pretty easy. You can use the API provisions that allows multiple projects to consume the same AWS Cognito pool. 
+Now that you have registered your users with their attributes in the AWS Cognito pool and your database and you want to attach a second app which should use the same pool. Well, that's actually pretty easy. You can use the API provisions that allows multiple projects to consume the same AWS Cognito pool.
 
 *IMPORTANT: if your users table has a password field you are not going to need this anymore. What you want to do is set this field to be nullable, so that users can be created without passwords. From now on, Passwords are stored in Cognito.
 
-Any additional registration data you have, for example `firstname`, `lastname` needs to be added in 
-[cognito.php](/config/cognito.php) cognito_user_fields config to be pushed to Cognito. Otherwise they are only stored locally 
+Any additional registration data you have, for example `firstname`, `lastname` needs to be added in
+[cognito.php](/config/cognito.php) cognito_user_fields config to be pushed to Cognito. Otherwise they are only stored locally
 and are not available if you want to use Single Sign On's.*
 
 ## Forgot password with resend option
@@ -204,13 +212,13 @@ To use the middleware into the **API routes**, as shown below
 ```
 
 
-## Registering Users 
+## Registering Users
 
 As a default, if you are registering a new user with Cognito, Cognito will send you an email during signUp that includes the username and temporary password for the users to verify themselves.
 
 Using this library in conjunction with **AWS Lambda**, once can look to customize the email template and content. The email template can be text or html based. The Lambda code for not included in this code repository. You can create your own. Any object (array) that you pass to the registration method is transferred as is to the lambda function, we are not prescriptive about the attribute names.
 
-We have made is very easy for anyone to use the default behaviour. 
+We have made is very easy for anyone to use the default behaviour.
 
 1. You don't need to create an extra field to store the verification token.
 2. You don't have to bother about the Sessions or API tokens, they are managed for you. The session or token is managed via the standard mechanism of Laravel. You have the liberty to keep it where ever you want, no security loop holes.
@@ -265,6 +273,14 @@ We have made is very easy for anyone to use the default behaviour.
 ```php
 
     AWS_COGNITO_FORCE_NEW_USER_EMAIL_VERIFIED=false
+
+```
+
+8. To assign a default group to a new user when registering set COGNITO_DEFAULT_USER_GROUP (or `default_user_group` in the config) to the name of a user group set in Cognito.
+
+```php
+
+    COGNITO_DEFAULT_USER_GROUP="Customers"
 
 ```
 
@@ -396,7 +412,7 @@ In case you want to use this trait for API based login, you can write the code a
 ## Delete User
 
 If you want to give your users the ability to delete themselves from your app you can use our deleteUser function
-from the CognitoClient. 
+from the CognitoClient.
 
 To delete the user you should call deleteUser and pass the email of the user as a parameter to it.
 After the user has been deleted in your cognito pool, delete your user from your database too.
@@ -406,19 +422,19 @@ After the user has been deleted in your cognito pool, delete your user from your
         $user->delete();
 ```
 
-We have implemented a new config option `delete_user`, which you can access through `AWS_COGNITO_DELETE_USER` env var. 
-If you set this config to true, the user is deleted in the Cognito pool. If it is set to false, it will stay registered. 
-Per default this option is set to false. If you want this behaviour you should set USE_SSO to true to let the user 
+We have implemented a new config option `delete_user`, which you can access through `AWS_COGNITO_DELETE_USER` env var.
+If you set this config to true, the user is deleted in the Cognito pool. If it is set to false, it will stay registered.
+Per default this option is set to false. If you want this behaviour you should set USE_SSO to true to let the user
 restore themselves after a successful login.
 
-To access our CognitoClient you can simply pass it as a parameter to your Controller Action where you want to perform 
-the deletion. 
+To access our CognitoClient you can simply pass it as a parameter to your Controller Action where you want to perform
+the deletion.
 
 ```php
     public function deleteUser(Request $request, AwsCognitoClient $client)
 ```
 
-Laravel will take care of the dependency injection by itself. 
+Laravel will take care of the dependency injection by itself.
 
 ```
     IMPORTANT: You want to secure this action by maybe security questions, a second delete password or by confirming 
@@ -430,7 +446,7 @@ Laravel will take care of the dependency injection by itself.
 If you have a deployment architecture, that involves multiple servers and you want to maintain the web sessions or API tokens across the servers, you can use the AWS DynamoDB. The library is capable of handling the DynamoDB with ease. All that you need to do is create the table in AWS DynamoDB and change a few configurations.
 
 ### Creating a new table in AWS DynamoDB
-1. Go to the AWS Console and create a new table. 
+1. Go to the AWS Console and create a new table.
 2. Enter the unique table name as per your preferences.
 3. The primary key (or partition key) should be **key** of type **string**
 4. Use default settings and click the **Create** button

--- a/README.md
+++ b/README.md
@@ -1,14 +1,7 @@
-<img src="https://cdn.ellaisys.com/aws-cognito/banner.png" width="100%" alt="EllaiSys AWS Cloud Capability"/>
-
 # Laravel Package to manage Web and API authentication with AWS Cognito
 AWS Cognito package using the AWS SDK for PHP
+Adapted for use with a pure api
 
-![Latest Version on Packagist](https://img.shields.io/packagist/v/ellaisys/aws-cognito?style=flat-square)
-![Release Date](https://img.shields.io/github/release-date/ellaisys/aws-cognito?style=flat-square)
-![Total Downloads](https://img.shields.io/packagist/dt/ellaisys/aws-cognito?style=flat-square)
-![](https://img.shields.io/github/stars/ellaisys/aws-cognito?style=flat-square) 
-![](https://img.shields.io/github/forks/ellaisys/aws-cognito?style=flat-square)
-![APM](https://img.shields.io/packagist/l/ellaisys/aws-cognito?style=flat-square)
 
 This package provides a simple way to use AWS Cognito authentication in Laravel 7.x for Web and API Auth Drivers.
 The idea of this package, and some of the code, is based on the package from Pod-Point which you can find here: [Pod-Point/laravel-cognito-auth](https://github.com/Pod-Point/laravel-cognito-auth), [black-bits/laravel-cognito-auth](https://github.com/black-bits/laravel-cognito-auth) and [tymondesigns/jwt-auth](https://github.com/tymondesigns/jwt-auth).

--- a/config/config.php
+++ b/config/config.php
@@ -74,6 +74,21 @@ return [
     */
     'add_user_delivery_mediums'     => env('AWS_COGNITO_ADD_USER_DELIVERY_MEDIUMS', 'DEFAULT'),
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cognito Default User Group
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default cognito user group assigned to a user
+    | when added to a User Pool.  Leave null if not assigning a group on
+    | registration.
+    |
+    |
+     */
+    'default_user_group' => env('COGNITO_DEFAULT_USER_GROUP'),
+
+
     /*
     |--------------------------------------------------------------------------
     | SSO Settings
@@ -93,7 +108,7 @@ return [
     | Token Store
     |--------------------------------------------------------------------------
     |
-    | This option controls the default store connection provider that gets used 
+    | This option controls the default store connection provider that gets used
     | while persisting the token. You can use the providers in the cache config.
     |
     */
@@ -104,14 +119,14 @@ return [
     | Cognito Challenge Status Names for Forced Access.
     |--------------------------------------------------------------------------
     |
-    | This option controls the package action based on the Challenge Status 
-    | received from the AWS Cognito Authentication. If the challenge status 
-    | is 'NEW_PASSWORD_CHALLENGE' and/or 'RESET_REQUIRED_PASSWORD', the 
+    | This option controls the package action based on the Challenge Status
+    | received from the AWS Cognito Authentication. If the challenge status
+    | is 'NEW_PASSWORD_CHALLENGE' and/or 'RESET_REQUIRED_PASSWORD', the
     | configuration that follows below will execute.
     |
     */
     'forced_challenge_names' => [
-        AwsCognitoClient::NEW_PASSWORD_CHALLENGE, 
+        AwsCognitoClient::NEW_PASSWORD_CHALLENGE,
         AwsCognitoClient::RESET_REQUIRED_PASSWORD
     ],
 
@@ -122,10 +137,10 @@ return [
     |
     | This setting controls the action, in case the AWS Cognito authentication
     | response includes the Challenge Names defined by 'forced_challenge_names'
-    | configuration in this file. The below flag, if set to 'true', will force 
-    | the web application user to be directed to certain route view/page. 
+    | configuration in this file. The below flag, if set to 'true', will force
+    | the web application user to be directed to certain route view/page.
     |
-    | In case the route name needs to be changed, you can set the below parameter 
+    | In case the route name needs to be changed, you can set the below parameter
     | and map it in web.php route page.
     |
     */
@@ -139,7 +154,7 @@ return [
     |
     | This setting controls the action, in case the AWS Cognito authentication
     | response includes the Challenge Names defined by 'forced_challenge_names'
-    | configuration in this file. The below flag, if set to 'true', will force 
+    | configuration in this file. The below flag, if set to 'true', will force
     | the user requesting API authentication by sharing the data required for
     | changing the password.
     |
@@ -151,7 +166,7 @@ return [
     | Force Auto Password Update based on Cognito Status in API Request (Token Guard)
     |--------------------------------------------------------------------------
     |
-    | This option enables the password to be auto updated into the AWS Cognito 
+    | This option enables the password to be auto updated into the AWS Cognito
     | User Pool. This feature will work only if the 'force_password_change_api'
     | is set to false.
     |
@@ -163,7 +178,7 @@ return [
     | Allow forgot password to resend the request based on Cognito User Status
     |--------------------------------------------------------------------------
     |
-    | This option enables the user to request for password from the AWS Cognito 
+    | This option enables the user to request for password from the AWS Cognito
     | User Pool, where the user is not with confirmed status.
     |
     */
@@ -186,7 +201,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option enables the new user message action. You can set the value to
-    | SUPPRESS in order to stop the invitation mails from being sent. The default 
+    | SUPPRESS in order to stop the invitation mails from being sent. The default
     | value is set to null.
     |
     */

--- a/src/Auth/ChangePasswords.php
+++ b/src/Auth/ChangePasswords.php
@@ -39,7 +39,6 @@ trait ChangePasswords
      */
     public function reset($request, string $paramUsername='email', string $passwordOld='password', string $passwordNew='new_password')
     {
-
         if ($request instanceof Request) {
             //Validate request
             $validator = Validator::make($request->all(), $this->rules());
@@ -50,7 +49,6 @@ trait ChangePasswords
 
             $request = collect($request->all());
         } //End if
-
 
         //Create AWS Cognito Client
         $client = app()->make(AwsCognitoClient::class);

--- a/src/Auth/ChangePasswords.php
+++ b/src/Auth/ChangePasswords.php
@@ -34,11 +34,12 @@ trait ChangePasswords
      * @param  string  $paramUsername (optional)
      * @param  string  $passwordOld (optional)
      * @param  string  $passwordNew (optional)
-     * 
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
     public function reset($request, string $paramUsername='email', string $passwordOld='password', string $passwordNew='new_password')
     {
+
         if ($request instanceof Request) {
             //Validate request
             $validator = Validator::make($request->all(), $this->rules());
@@ -50,11 +51,13 @@ trait ChangePasswords
             $request = collect($request->all());
         } //End if
 
+
         //Create AWS Cognito Client
         $client = app()->make(AwsCognitoClient::class);
 
         //Get User Data
         $user = $client->getUser($request[$paramUsername]);
+
         if (empty($user)) {
             $response = response()->json(['error' => 'cognito.validation.reset_required.invalid_email'], 400);
         } else {
@@ -84,7 +87,7 @@ trait ChangePasswords
      * @param  string  $paramUsername
      * @param  string  $passwordOld
      * @param  string  $passwordNew
-     * 
+     *
      * @return string
      */
     private function forceNewPassword(AwsCognitoClient $client, $request, string $paramUsername, string $passwordOld, string $passwordNew)
@@ -105,7 +108,7 @@ trait ChangePasswords
      * @param  string  $paramUsername
      * @param  string  $passwordOld
      * @param  string  $passwordNew
-     * 
+     *
      * @return string
      */
     private function changePassword(AwsCognitoClient $client, $request, string $paramUsername, string $passwordOld, string $passwordNew)

--- a/src/Auth/RegistersUsers.php
+++ b/src/Auth/RegistersUsers.php
@@ -40,6 +40,7 @@ trait RegistersUsers
         $this->validator($request->all())->validate();
 
         $data = $request->all();
+        // Generate random password if none provided
         if(empty($data['password'])) {
             $data['password'] = bin2hex(openssl_random_pseudo_bytes(10));
         }
@@ -60,6 +61,8 @@ trait RegistersUsers
             $this->setDefaultGroup($user->email);
         } //End if
 
+
+        // Return with user data
         return $request->wantsJson()
             ? new JsonResponse($user, 201)
             : redirect($this->redirectPath());

--- a/src/AwsCognitoClient.php
+++ b/src/AwsCognitoClient.php
@@ -383,7 +383,7 @@ class AwsCognitoClient
      * @param string $messageAction (optional)
      * @return bool $isUserEmailForcedVerified (false)
      */
-    public function inviteUser(string $username, string $password=null, array $attributes = [], 
+    public function inviteUser(string $username, string $password=null, array $attributes = [],
                                array $clientMetadata=null, string $messageAction=null,
                                bool $isUserEmailForcedVerified = false)
     {

--- a/src/AwsCognitoClient.php
+++ b/src/AwsCognitoClient.php
@@ -326,6 +326,52 @@ class AwsCognitoClient
         return Password::PASSWORD_RESET;
     } //Function ends
 
+    /**
+     * Gets the user's groups from Cognito
+     *
+     * @param string $username
+     * @return \Aws\Result
+     */
+    public function adminListGroupsForUser(string $username)
+    {
+        try {
+            $groups = $this->client->AdminListGroupsForUser([
+                    'UserPoolId' => $this->poolId, // REQUIRED
+                    'Username' => $username // REQUIRED
+                ]
+            );
+            return $groups;
+        } catch (CognitoIdentityProviderException $e) {
+            throw $e;
+        } //Try-catch ends
+
+        return false;
+    }
+
+    /**
+     * Add a user to a given group
+     *
+     * @param string $username
+     * @param string $groupname
+     * @return bool
+     */
+    public function adminAddUserToGroup(string $username, string $groupname)
+    {
+
+        try {
+            $this->client->adminAddUserToGroup([
+                    'GroupName' => $groupname, // REQUIRED
+                    'UserPoolId' => $this->poolId, // REQUIRED
+                    'Username' => $username // REQUIRED
+                ]
+            );
+        } catch (CognitoIdentityProviderException $e) {
+            throw $e;
+        } //Try-catch ends
+
+        return true;
+    } //Function ends
+
 
     /**
      * Register a user and send them an email to set their password.


### PR DESCRIPTION
The following was added in to this PR to connect Cognito Groups, allowing administrators to manage user groups from the Cognito interface:
- RegistersUsers Trait: Added a function called setDefaultGroup which looks for a config item called `cognito.default_user_group`, and if it exists calls the Cognito Admin API to add the user to the group.
- Calls the above function from the `register` function in the same trait
- Adds the following to the `AwsCognitoClient` Class:
 -- `adminAddUserToGroup` to add a user to a given group
 -- `adminListGroupsForUser` which returns groups a user belongs to - this can be used in the application code to get the user's known groups, or synchronize a local data store with info from Cognito
- Adds `getAdminListGroupsForUser` to the `AuthenticatesUsers` trait, to pull the above functionality up to the application code
- Fixed a bug found in `createLocalUser` function in AuthenticatesUsers trait, which was throwing an error in Laravel 9 running on PHP 7.4